### PR TITLE
Fixed broken package statement in MultiGpuVGG16TinyImageNetExample

### DIFF
--- a/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/MultiGpuVGG16TinyImageNetExample.java
+++ b/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/MultiGpuVGG16TinyImageNetExample.java
@@ -1,4 +1,4 @@
-VGG16package org.deeplearning4j.examples.multigpu.vgg16;
+package org.deeplearning4j.examples.multigpu.vgg16;
 
 import org.datavec.api.io.filters.RandomPathFilter;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;


### PR DESCRIPTION
## What changes were proposed in this pull request?

An incorrectly added typo was removed. 

The PR restores compilability of the examples.